### PR TITLE
Add Emacs 30 containerized config test job

### DIFF
--- a/.github/workflows/config-ci.yml
+++ b/.github/workflows/config-ci.yml
@@ -44,9 +44,7 @@ jobs:
         if: runner.os == 'Windows'
         uses: actions/cache@v4
         with:
-          path: |
-            C:\ProgramData\chocolatey\cache
-            C:\ProgramData\chocolatey\lib
+          path: C:\ProgramData\chocolatey\cache
           key: ${{ runner.os }}-choco-emacs-v1
           restore-keys: |
             ${{ runner.os }}-choco-emacs-

--- a/.github/workflows/config-ci.yml
+++ b/.github/workflows/config-ci.yml
@@ -44,7 +44,7 @@ jobs:
         if: runner.os == 'Windows'
         uses: actions/cache@v4
         with:
-          path: C:\ProgramData\chocolatey\cache
+          path: C:\ProgramData\chocolatey\lib\emacs.portable
           key: ${{ runner.os }}-choco-emacs-v1
           restore-keys: |
             ${{ runner.os }}-choco-emacs-

--- a/.github/workflows/config-ci.yml
+++ b/.github/workflows/config-ci.yml
@@ -22,20 +22,44 @@ concurrency:
 
 jobs:
   core-static:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Emacs
+      - name: Install Emacs (Ubuntu)
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y emacs-nox
 
-      - name: Run core static battery
+      - name: Install Emacs (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew update
+          brew install emacs
+
+      - name: Install Emacs (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          choco install emacs --yes --no-progress
+
+      - name: Run core static battery (Unix)
+        if: runner.os != 'Windows'
         run: |
           chmod +x tests/run-battery.sh tests/tramp/*.sh
           TEST_SUITE=core-static ./tests/run-battery.sh
+
+      - name: Run core static battery (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          bash -lc "chmod +x tests/run-battery.sh tests/tramp/*.sh && TEST_SUITE=core-static ./tests/run-battery.sh"
 
   core-static-emacs30-container:
     runs-on: ubuntu-latest

--- a/.github/workflows/config-ci.yml
+++ b/.github/workflows/config-ci.yml
@@ -31,6 +31,26 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Cache Homebrew downloads
+        if: runner.os == 'macOS'
+        uses: actions/cache@v4
+        with:
+          path: ~/Library/Caches/Homebrew
+          key: ${{ runner.os }}-brew-emacs-v1
+          restore-keys: |
+            ${{ runner.os }}-brew-emacs-
+
+      - name: Cache Chocolatey packages
+        if: runner.os == 'Windows'
+        uses: actions/cache@v4
+        with:
+          path: |
+            C:\ProgramData\chocolatey\cache
+            C:\ProgramData\chocolatey\lib
+          key: ${{ runner.os }}-choco-emacs-v1
+          restore-keys: |
+            ${{ runner.os }}-choco-emacs-
+
       - name: Install Emacs (Ubuntu)
         if: runner.os == 'Linux'
         run: |
@@ -40,7 +60,6 @@ jobs:
       - name: Install Emacs (macOS)
         if: runner.os == 'macOS'
         run: |
-          brew update
           brew install emacs
 
       - name: Install Emacs (Windows)
@@ -68,7 +87,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build cached Emacs 30 image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./tests
+          file: ./tests/Dockerfile.emacs30-sid
+          tags: emacs30-sid:local
+          load: true
+          cache-from: type=gha,scope=emacs30-sid
+          cache-to: type=gha,mode=max,scope=emacs30-sid
+
       - name: Run core static + platform smoke in Emacs 30 container
         run: |
           chmod +x tests/run-emacs30-container.sh tests/run-battery.sh tests/tramp/*.sh
-          TEST_SUITE=core-static RUN_TRAMP_SMOKE=1 ./tests/run-emacs30-container.sh
+          TEST_SUITE=core-static RUN_TRAMP_SMOKE=1 EMACS30_SKIP_BUILD=1 ./tests/run-emacs30-container.sh

--- a/.github/workflows/config-ci.yml
+++ b/.github/workflows/config-ci.yml
@@ -44,10 +44,17 @@ jobs:
         if: runner.os == 'Windows'
         uses: actions/cache@v4
         with:
-          path: C:\ProgramData\chocolatey\lib\emacs.portable
-          key: ${{ runner.os }}-choco-emacs-v1
+          path: C:\ProgramData\chocolatey\cache
+          key: ${{ runner.os }}-choco-emacs-v2
           restore-keys: |
             ${{ runner.os }}-choco-emacs-
+
+      - name: Configure Chocolatey download cache
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          New-Item -Path 'C:\ProgramData\chocolatey\cache' -ItemType Directory -Force | Out-Null
+          choco config set cacheLocation C:\ProgramData\chocolatey\cache
 
       - name: Install Emacs (Ubuntu)
         if: runner.os == 'Linux'

--- a/.github/workflows/config-ci.yml
+++ b/.github/workflows/config-ci.yml
@@ -36,3 +36,15 @@ jobs:
         run: |
           chmod +x tests/run-battery.sh tests/tramp/*.sh
           TEST_SUITE=core-static ./tests/run-battery.sh
+
+  core-static-emacs30-container:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run core static + platform smoke in Emacs 30 container
+        run: |
+          chmod +x tests/run-emacs30-container.sh tests/run-battery.sh tests/tramp/*.sh
+          TEST_SUITE=core-static RUN_TRAMP_SMOKE=1 ./tests/run-emacs30-container.sh

--- a/tests/Dockerfile.emacs30-sid
+++ b/tests/Dockerfile.emacs30-sid
@@ -1,0 +1,12 @@
+FROM debian:sid
+
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+       bash \
+       ca-certificates \
+       emacs-gtk \
+       git \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /repo
+CMD ["bash"]

--- a/tests/README.md
+++ b/tests/README.md
@@ -10,6 +10,7 @@ This repository uses test batteries under `tests/`.
 - `core-static`: shell syntax + Emacs Lisp parse checks.
 - `tramp-ci-direct`: run TRAMP direct scenario battery.
 - `tramp-ci-bastion`: run TRAMP bastion scenario battery.
+- `tests/run-emacs30-container.sh`: build a Debian sid container with Emacs 30.2 and run batteries inside it.
 
 ## Real host integration (manual CI)
 - Workflow: `.github/workflows/tramp-real-integration.yml`
@@ -30,3 +31,13 @@ Example:
 ```bash
 TEST_SUITE=core-static ./tests/run-battery.sh
 ```
+
+Containerized Emacs 30 run (includes TRAMP platform smoke by default):
+
+```bash
+TEST_SUITE=core-static ./tests/run-emacs30-container.sh
+```
+
+Optional env vars:
+- `EMACS30_IMAGE_TAG` (default: `emacs30-sid:local`)
+- `RUN_TRAMP_SMOKE` (`1` by default, set `0` to skip `tests/tramp/smoke-platform.el`)

--- a/tests/README.md
+++ b/tests/README.md
@@ -41,3 +41,4 @@ TEST_SUITE=core-static ./tests/run-emacs30-container.sh
 Optional env vars:
 - `EMACS30_IMAGE_TAG` (default: `emacs30-sid:local`)
 - `RUN_TRAMP_SMOKE` (`1` by default, set `0` to skip `tests/tramp/smoke-platform.el`)
+- `EMACS30_SKIP_BUILD` (`0` by default, set `1` to use a prebuilt image tag)

--- a/tests/README.md
+++ b/tests/README.md
@@ -7,7 +7,7 @@ This repository uses test batteries under `tests/`.
 - `tests/run-battery.sh`: top-level battery entrypoint.
 
 ## Top-level suites
-- `core-static`: shell syntax + Emacs Lisp parse checks.
+- `core-static`: shell syntax checks for tracked `*.sh` plus Emacs Lisp parse checks for tracked `*.el`.
 - `tramp-ci-direct`: run TRAMP direct scenario battery.
 - `tramp-ci-bastion`: run TRAMP bastion scenario battery.
 - `tests/run-emacs30-container.sh`: build a Debian sid container with Emacs 30.2 and run batteries inside it.

--- a/tests/run-battery.sh
+++ b/tests/run-battery.sh
@@ -9,7 +9,10 @@ run_core_static() {
   bash -n "${ROOT_DIR}/tramp/"*.sh
 
   echo "== Emacs Lisp syntax checks =="
-  mapfile -d '' elisp_files < <(git -C "${ROOT_DIR}/.." ls-files -z '*.el')
+  local elisp_files=()
+  while IFS= read -r -d '' file; do
+    elisp_files+=("${file}")
+  done < <(git -C "${ROOT_DIR}/.." ls-files -z '*.el')
   if [[ "${#elisp_files[@]}" -eq 0 ]]; then
     echo "No elisp files found."
     return

--- a/tests/run-battery.sh
+++ b/tests/run-battery.sh
@@ -6,13 +6,33 @@ SUITE="${TEST_SUITE:-core-static}"
 
 run_core_static() {
   echo "== Shell syntax checks =="
-  bash -n "${ROOT_DIR}/tramp/"*.sh
+  local shell_files=()
+  if git -C "${ROOT_DIR}/.." rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    while IFS= read -r -d '' file; do
+      shell_files+=("${ROOT_DIR}/../${file}")
+    done < <(git -C "${ROOT_DIR}/.." ls-files -z '*.sh')
+  else
+    while IFS= read -r -d '' file; do
+      shell_files+=("${file}")
+    done < <(find "${ROOT_DIR}/.." -type f -name '*.sh' -print0)
+  fi
+  if [[ "${#shell_files[@]}" -eq 0 ]]; then
+    echo "No shell scripts found."
+  else
+    bash -n "${shell_files[@]}"
+  fi
 
   echo "== Emacs Lisp syntax checks =="
   local elisp_files=()
-  while IFS= read -r -d '' file; do
-    elisp_files+=("${file}")
-  done < <(git -C "${ROOT_DIR}/.." ls-files -z '*.el')
+  if git -C "${ROOT_DIR}/.." rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    while IFS= read -r -d '' file; do
+      elisp_files+=("${file}")
+    done < <(git -C "${ROOT_DIR}/.." ls-files -z '*.el')
+  else
+    while IFS= read -r -d '' file; do
+      elisp_files+=("${file#${ROOT_DIR}/../}")
+    done < <(find "${ROOT_DIR}/.." -type f -name '*.el' -print0)
+  fi
   if [[ "${#elisp_files[@]}" -eq 0 ]]; then
     echo "No elisp files found."
     return

--- a/tests/run-emacs30-container.sh
+++ b/tests/run-emacs30-container.sh
@@ -6,14 +6,19 @@ DOCKERFILE="${ROOT_DIR}/tests/Dockerfile.emacs30-sid"
 IMAGE_TAG="${EMACS30_IMAGE_TAG:-emacs30-sid:local}"
 SUITE="${TEST_SUITE:-core-static}"
 RUN_TRAMP_SMOKE="${RUN_TRAMP_SMOKE:-1}"
+SKIP_BUILD="${EMACS30_SKIP_BUILD:-0}"
 
 if ! command -v docker >/dev/null 2>&1; then
   echo "docker is required but was not found in PATH" >&2
   exit 1
 fi
 
-echo "== Building ${IMAGE_TAG} from ${DOCKERFILE} =="
-docker build -f "${DOCKERFILE}" -t "${IMAGE_TAG}" "${ROOT_DIR}/tests"
+if [[ "${SKIP_BUILD}" != "1" ]]; then
+  echo "== Building ${IMAGE_TAG} from ${DOCKERFILE} =="
+  docker build -f "${DOCKERFILE}" -t "${IMAGE_TAG}" "${ROOT_DIR}/tests"
+else
+  echo "== Using prebuilt image ${IMAGE_TAG} =="
+fi
 
 container_cmd='
 set -euo pipefail

--- a/tests/run-emacs30-container.sh
+++ b/tests/run-emacs30-container.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DOCKERFILE="${ROOT_DIR}/tests/Dockerfile.emacs30-sid"
+IMAGE_TAG="${EMACS30_IMAGE_TAG:-emacs30-sid:local}"
+SUITE="${TEST_SUITE:-core-static}"
+RUN_TRAMP_SMOKE="${RUN_TRAMP_SMOKE:-1}"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "docker is required but was not found in PATH" >&2
+  exit 1
+fi
+
+echo "== Building ${IMAGE_TAG} from ${DOCKERFILE} =="
+docker build -f "${DOCKERFILE}" -t "${IMAGE_TAG}" "${ROOT_DIR}/tests"
+
+container_cmd='
+set -euo pipefail
+mkdir -p /repo
+tar -C /repo -xf -
+cd /repo
+git config --global --add safe.directory /repo
+chmod +x tests/run-battery.sh tests/tramp/*.sh
+TEST_SUITE="${TEST_SUITE:-core-static}" ./tests/run-battery.sh
+if [[ "${RUN_TRAMP_SMOKE:-1}" == "1" ]]; then
+  emacs --batch -l tests/tramp/smoke-platform.el
+fi
+'
+
+echo "== Running suite ${SUITE} inside ${IMAGE_TAG} =="
+tar -C "${ROOT_DIR}" -cf - . \
+  | docker run --rm -i \
+      -e TEST_SUITE="${SUITE}" \
+      -e RUN_TRAMP_SMOKE="${RUN_TRAMP_SMOKE}" \
+      "${IMAGE_TAG}" \
+      bash -lc "${container_cmd}"


### PR DESCRIPTION
## Summary
- add `tests/Dockerfile.emacs30-sid` for a Debian sid Emacs 30.2 runtime
- add `tests/run-emacs30-container.sh` to run the existing battery in-container
- add `config-ci` job `core-static-emacs30-container` that runs the new script
- document the containerized test flow in `tests/README.md`

## Validation
- Ran locally: `TEST_SUITE=core-static RUN_TRAMP_SMOKE=1 ./tests/run-emacs30-container.sh`
- Result: core static checks pass; TRAMP platform smoke reports `OK: Emacs=30.2 System=gnu/linux TRAMP=2.7.3.30.2`
